### PR TITLE
Fix compat with GenericSchur and GenericSVD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 version = "0.2.4"
 
 [deps]
+GenericSchur = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 GenericSVD = "01680d73-4ee2-5a08-a1aa-533608c188bb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -17,4 +18,5 @@ test = ["Quaternions", "Test"]
 
 [compat]
 julia = "1.3"
+GenericSchur = "0.4"
 GenericSVD = "0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 version = "0.2.4"
 
 [deps]
+GenericSVD = "01680d73-4ee2-5a08-a1aa-533608c188bb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -16,3 +17,4 @@ test = ["Quaternions", "Test"]
 
 [compat]
 julia = "1.3"
+GenericSVD = "0.3"

--- a/src/GenericLinearAlgebra.jl
+++ b/src/GenericLinearAlgebra.jl
@@ -1,6 +1,7 @@
 module GenericLinearAlgebra
 
 import LinearAlgebra: mul!, ldiv!
+import GenericSVD
 
 include("juliaBLAS.jl")
 include("lapack.jl")

--- a/src/GenericLinearAlgebra.jl
+++ b/src/GenericLinearAlgebra.jl
@@ -1,7 +1,7 @@
 module GenericLinearAlgebra
 
 import LinearAlgebra: mul!, ldiv!
-import GenericSVD
+import GenericSVD, GenericSchur
 
 include("juliaBLAS.jl")
 include("lapack.jl")

--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -36,14 +36,6 @@ function LinearAlgebra.ldiv!(H::HessenbergMatrix, B::AbstractVecOrMat)
     ldiv!(Triangular(Hd, :U), B)
 end
 
-# Hessenberg factorization
-struct HessenbergFactorization{T, S<:StridedMatrix,U} <: Factorization{T}
-    data::S
-    τ::Vector{U}
-end
-
-Base.size(H::HessenbergFactorization, args...) = size(H.data, args...)
-
 # Schur
 struct Schur{T,S<:StridedMatrix} <: Factorization{T}
     data::S
@@ -66,7 +58,7 @@ end
 
 # We currently absorb extra unsupported keywords in kwargs. These could e.g. be scale and permute. Do we want to check that these are false?
 function _schur!(
-    H::HessenbergFactorization{T};
+    H::GenericSchur.HessenbergArg{T};
     tol = eps(real(T)),
     debug = false,
     shiftmethod = :Francis,
@@ -76,7 +68,7 @@ function _schur!(
     n = size(H, 1)
     istart = 1
     iend = n
-    HH = H.data
+    HH = GenericSchur._getdata(H)
     τ = Rotation(Givens{T}[])
 
     # iteration count
@@ -230,7 +222,7 @@ end
 
 _eigvals!(A::StridedMatrix; kwargs...)           = _eigvals!(_schur!(A; kwargs...))
 _eigvals!(H::HessenbergMatrix; kwargs...)        = _eigvals!(_schur!(H; kwargs...))
-_eigvals!(H::HessenbergFactorization; kwargs...) = _eigvals!(_schur!(H; kwargs...))
+_eigvals!(H::GenericSchur.HessenbergArg; kwargs...) = _eigvals!(_schur!(H; kwargs...))
 
 # Overload methods from LinearAlgebra to make them work generically
 if VERSION > v"1.2.0-DEV.0"
@@ -251,7 +243,7 @@ if VERSION > v"1.2.0-DEV.0"
         kwargs...) = LinearAlgebra.sorteig!(_eigvals!(H; kwargs...), sortby)
 
     LinearAlgebra.eigvals!(
-        H::HessenbergFactorization;
+        H::GenericSchur.HessenbergArg;
         sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby,
         kwargs...) = LinearAlgebra.sorteig!(_eigvals!(H; kwargs...), sortby)
 else
@@ -265,7 +257,7 @@ else
 
     LinearAlgebra.eigvals!(H::HessenbergMatrix; kwargs...) = _eigvals!(H; kwargs...)
 
-    LinearAlgebra.eigvals!(H::HessenbergFactorization; kwargs...) = _eigvals!(H; kwargs...)
+    LinearAlgebra.eigvals!(H::GenericSchur.HessenbergArg; kwargs...) = _eigvals!(H; kwargs...)
 end
 
 # To compute the eigenvalue of the pseudo triangular Schur matrix we just return

--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -42,21 +42,6 @@ struct HessenbergFactorization{T, S<:StridedMatrix,U} <: Factorization{T}
     τ::Vector{U}
 end
 
-function _hessenberg!(A::StridedMatrix{T}) where T
-    n = LinearAlgebra.checksquare(A)
-    τ = Vector{Householder{T}}(undef, n - 1)
-    for i = 1:n - 1
-        xi = view(A, i + 1:n, i)
-        t  = LinearAlgebra.reflector!(xi)
-        H  = Householder{T,typeof(xi)}(view(xi, 2:n - i), t)
-        τ[i] = H
-        lmul!(H', view(A, i + 1:n, i + 1:n))
-        rmul!(view(A, :, i + 1:n), H)
-    end
-    return HessenbergFactorization{T, typeof(A), eltype(τ)}(A, τ)
-end
-LinearAlgebra.hessenberg!(A::StridedMatrix) = _hessenberg!(A)
-
 Base.size(H::HessenbergFactorization, args...) = size(H.data, args...)
 
 # Schur
@@ -166,7 +151,7 @@ function _schur!(
 
     return Schur{T,typeof(HH)}(HH, τ)
 end
-_schur!(A::StridedMatrix; kwargs...) = _schur!(_hessenberg!(A); kwargs...)
+_schur!(A::StridedMatrix; kwargs...) = _schur!(hessenberg!(A); kwargs...)
 LinearAlgebra.schur!(A::StridedMatrix; kwargs...) = _schur!(A; kwargs...)
 
 function singleShiftQR!(HH::StridedMatrix, τ::Rotation, shift::Number, istart::Integer, iend::Integer)

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -13,28 +13,6 @@ QR2(factors::AbstractMatrix{T}, τ::Vector{T}) where {T} = QR2{T,typeof(factors)
 
 size(F::QR2, i::Integer...) = size(F.factors, i...)
 
-# Similar to the definition in base but applies the reflector from the right
-@inline function reflectorApply!(A::StridedMatrix, x::AbstractVector, τ::Number) # apply conjugate transpose reflector from right.
-    m, n = size(A)
-    if length(x) != n
-        throw(DimensionMismatch("reflector must have same length as second dimension of matrix"))
-    end
-    @inbounds begin
-        for i in 1:m
-            Aiv = A[i, 1]
-            for j in 2:n
-                Aiv += A[i, j]*x[j]
-            end
-            Aiv = Aiv*τ
-            A[i, 1] -= Aiv
-            for j in 2:n
-                A[i, j] -= Aiv*x[j]'
-            end
-        end
-    end
-    return A
-end
-
 # FixMe! Consider how to represent Q
 
 # immutable Q{T,S<:QR2} <: AbstractMatrix{T}

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -2,9 +2,6 @@ using LinearAlgebra
 
 import LinearAlgebra: mul!, rmul!
 
-lmul!(G::LinearAlgebra.Givens, ::Nothing) = nothing
-rmul!(::Nothing, G::LinearAlgebra.Givens) = nothing
-
 function svdvals2x2(d1, d2, e)
     d1sq = d1*d1
     d2sq = d2*d2


### PR DESCRIPTION
The general type piracy in this package here, `GenericSVD` and `GenericSchur` recently broke precompile across an incredibly large number of packages, for example pretty much all of Queryverse. This PR is an (incomplete) attempt to improve on the current situation.

The backstory is that this package here, `GenericSVD` and `GenericSchur` all commit type piracy with `LinearAlgebra` methods, and in some cases the three packages add the same methods. The net effect is that if one tries to load these packages simultaneously, precompile is broken. This issue was brought up before (https://github.com/JuliaLinearAlgebra/GenericLinearAlgebra.jl/issues/60) and the suggested resolution was that one shouldn't use these packages at the same time. I think this is no longer a realistic position: there are many packages that pull these packages here in, and so as an end-user it is way too easy to end up with multiple packages via indirect dependencies, an incredibly frustrating experience. Where this hit recently is that `DoubleFloats` has a dependency on `GenericSVD` and `GenericSchur` and `Polynomials`, and `Polynomials` has a dependency on `GenericLinearAlgebra` (thanks @pearlzli and @GregPlowman for figuring this out!), so any package that depends on `DoubleFloats` currently has precompile broken, which via `TextParse` is for example a huge part of `Queryverse`.

This PR here tries to tackle the problem in the following way: wherever `GenericLinearAlgebra` added a method that is _also_ present in `GenericSVD` or `GenericSchur`, I removed that method in `GenericLinearAlgebra`, so that the version in `GenericSVD` or `GenericSchur` is used instead. These methods were literally identical, so I think this should be mostly a very harmless change.

As part of that I also made use of the `Hessenberg` struct in newer versions of Julia that is already used in GenericSchur. That part required me to use some internals from `GenericSchur`, @RalphAS would you be willing to treat these internal details as part of the public interface of `GenericSchur`, insofar that you would bump the major version of the package if you changed anything about that? This might also constitute a breaking change, I guess.

This PR gets rid of a lot of the conflicts, but not all of them. There is still a problem with `schur!` and `eigvals!` that I was not able to solve, primarily because at first sight the implementation in `GenericLinearAlgebra` and `GenericSchur` looked quite different, so I was not sure what to do there. @RalphAS and @andreasnoack do you have an idea? To see what exactly is still broken, just run the tests on this branch and you should get the relevant warning messages. My gut sense is that `GenericLinearAlgebra` should probably hook into `GenericSchur.gschur!` somehow?

Also pinging @JeffreySarnoff (from `DoubleFloats`), @michakraus and @jverzani (from the `Polynomials` change) and @simonbyrne (from `GenericSVD`).

I would greatly appreciate it if we could try to find some solution for this as a priority because of the very large number of packages and users affected (and on a selfish note this is causing huge problems for an internal project at the moment as well).