### PR TITLE
wrapper for eigen(Matrix A) where A is hermitian by value but not type

### DIFF
--- a/src/eigenSelfAdjoint.jl
+++ b/src/eigenSelfAdjoint.jl
@@ -593,7 +593,6 @@ LinearAlgebra.eigen!(A::Hermitian;
                      tol = eps(real(eltype(A))),
                      debug = false) = _eigen!(A, tol = tol, debug = debug)
 
-
 function eigen2!(A::SymmetricTridiagonalFactorization;
                  tol = eps(real(float(one(eltype(A))))),
                  debug = false)
@@ -648,6 +647,12 @@ end
 function LinearAlgebra.eigen(A::Hermitian)
     T = typeof(sqrt(zero(eltype(A))))
     return eigen!(LinearAlgebra.copy_oftype(A, T))
+end
+function LinearAlgebra.eigen(A::Matrix)
+    if !ishermitian(A)
+         throw(ArgumentError("eigen not implement for non-Hermitian matrices of generic type (e.g. Matrix{BigFloat})"))
+    end
+    return eigen(Hermitian(A))
 end
 
 # Aux (should go somewhere else at some point)

--- a/test/eigengeneral.jl
+++ b/test/eigengeneral.jl
@@ -150,4 +150,12 @@ end
     @test sort(imag(vals)) ≈ sort(imag(λs)) atol=1e-25
 end
 
+@testset "Wrapper function for eigen(Matrix A) where A is hermitian by value but not by type" begin
+    # just need to verify that the wrapper function correctly calls eigen(Hermitian(A))
+    # so no need for multiple numeric tests
+    a = big(2.0);
+    A = [1 a; a 0] # A == A^*, but type is Matrix{BigFloat}, not Hermitian{BigFloat, Matrix{BigFloat}}
+    λs = [(1 - √(1+4a^2))/2 ; (1 + √(1+4a^2))/2]
+    vals = eigvals(A)
+    @test sort(vals) ≈ sort(λs) atol=1e-25
 end


### PR DESCRIPTION
A small fix to make the generic ``eigen`` work for matrices that are hermitian by value but not by type, following @dlfivefifty's suggestion at https://discourse.julialang.org/t/eigen-not-working-for-arbitrary-precision-bigfloat/67686/11