### PR TITLE
Adjustment to `AdjointQ` introduction in LinearAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]
+Quaternions = "=0.6.0"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GenericLinearAlgebra"
 uuid = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
-version = "0.3.3"
+version = "0.3.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -1,6 +1,11 @@
 using LinearAlgebra
 
 import LinearAlgebra: mul!, rmul!
+@static if VERSION > v"1.8"
+    AdjointQtype = LinearAlgebra.AdjointQ
+else
+    AdjointQtype = Adjoint
+end
 
 lmul!(G::LinearAlgebra.Givens, ::Nothing) = nothing
 rmul!(::Nothing, G::LinearAlgebra.Givens) = nothing
@@ -355,7 +360,7 @@ function lmul!(Q::LinearAlgebra.HessenbergQ, B::AbstractVecOrMat)
     return B
 end
 
-function lmul!(adjQ::Adjoint{<:Any,<:LinearAlgebra.HessenbergQ}, B::AbstractVecOrMat)
+function lmul!(adjQ::AdjointQtype{<:Any,<:LinearAlgebra.HessenbergQ}, B::AbstractVecOrMat)
 
     Q = parent(adjQ)
     m, n = size(B, 1), size(B, 2)
@@ -406,8 +411,7 @@ function rmul!(A::AbstractMatrix, Q::LinearAlgebra.HessenbergQ)
     return A
 end
 
-function rmul!(A::AbstractMatrix, adjQ::Adjoint{<:Any,<:LinearAlgebra.HessenbergQ})
-
+function rmul!(A::AbstractMatrix, adjQ::AdjointQtype{<:Any,<:LinearAlgebra.HessenbergQ})
     m, n = size(A)
     Q = parent(adjQ)
 

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -1,11 +1,8 @@
 using LinearAlgebra
 
 import LinearAlgebra: mul!, rmul!
-@static if VERSION >= v"1.9-"
-    AdjointQtype = LinearAlgebra.AdjointQ
-else
-    AdjointQtype = Adjoint
-end
+
+AdjointQtype = isdefined(LinearAlgebra, :AdjointQ) ? : LinearAlgebra.AdjointQ : Adjoint
 
 lmul!(G::LinearAlgebra.Givens, ::Nothing) = nothing
 rmul!(::Nothing, G::LinearAlgebra.Givens) = nothing

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -1,7 +1,7 @@
 using LinearAlgebra
 
 import LinearAlgebra: mul!, rmul!
-@static if VERSION > v"1.8"
+@static if VERSION >= v"1.9-"
     AdjointQtype = LinearAlgebra.AdjointQ
 else
     AdjointQtype = Adjoint

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -2,7 +2,7 @@ using LinearAlgebra
 
 import LinearAlgebra: mul!, rmul!
 
-AdjointQtype = isdefined(LinearAlgebra, :AdjointQ) ? : LinearAlgebra.AdjointQ : Adjoint
+AdjointQtype = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ : Adjoint
 
 lmul!(G::LinearAlgebra.Givens, ::Nothing) = nothing
 rmul!(::Nothing, G::LinearAlgebra.Givens) = nothing


### PR DESCRIPTION
This is a companion PR to https://github.com/JuliaLang/julia/pull/46196. ~~It will fail for the nightly version until that PR is merged (if it gets merged).~~ It should no longer fail because it checks if `AdjointQ` is defined, independently from any versions. In principle, if we agree on merging the stdlib PR, we could merge this even before that PR, release a new version and then it should no longer fail on either `master` or `PR`.