### PR TITLE
Make `R` field in `Schur` concretely typed

### DIFF
--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -62,7 +62,7 @@ Base.size(H::HessenbergFactorization, args...) = size(H.data, args...)
 # Schur
 struct Schur{T,S<:StridedMatrix} <: Factorization{T}
     data::S
-    R::Rotation
+    R::Rotation{T}
 end
 
 function Base.getproperty(F::Schur, s::Symbol)


### PR DESCRIPTION
Fixes #90. By line 95,

```julia
τ = Rotation(Givens{T}[])
```

the `R` field has eltype `T` for sure.