### PR TITLE
Use JuliaLinearAlgebra's Codecov token in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info


### PR DESCRIPTION
This is necessary to upload coverage reports using the v4 of the Codecov action