### PR TITLE
CI: Change `setup-julia@v2.2` to `setup-julia@v2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2.2
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
There seems to be a bug where Dependabot has trouble with `setup-julia@v2.2`, but does fine with `setup-julia@v2`. So let's just avoid the former.