### PR TITLE
CI: Change `setup-julia@latest` to `setup-julia@v2`

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - name: Install dependencies


### PR DESCRIPTION
In general, we should never use the `@latest` tag.

So let's switch to the `@v2` tag instead.