### PR TITLE
Remove some pirated methods for the symmetric eigenvalue problem.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 'min'
           - 'lts'
-          - 'nightly'
           - '1'
+          - 'pre'
         os:
           - ubuntu-latest
 #           - macos-latest

--- a/src/eigenSelfAdjoint.jl
+++ b/src/eigenSelfAdjoint.jl
@@ -216,7 +216,10 @@ function eigvalsPWK!(S::SymTridiagonal{T}; tol = eps(T), sortby::Union{Function,
             end
         end
     end
-    LinearAlgebra.sorteig!(d, sortby)
+
+    # LinearAlgebra.eigvals will pass sortby=nothing but LAPACK always sort the symmetric
+    # eigenvalue problem so we'll will do the same here
+    LinearAlgebra.sorteig!(d, sortby === nothing ? LinearAlgebra.eigsortby : sortby)
 end
 
 function eigQL!(
@@ -639,29 +642,31 @@ else
     LinearAlgebra.copy_oftype
 end
 
-function LinearAlgebra.eigvals(A::Hermitian{<:Real})
-    T = typeof(sqrt(zero(eltype(A))))
-    return eigvals!(_eigencopy_oftype(A, T))
-end
-function LinearAlgebra.eigvals(A::Hermitian{<:Complex})
-    T = typeof(sqrt(zero(eltype(A))))
-    return eigvals!(_eigencopy_oftype(A, T))
-end
-function LinearAlgebra.eigvals(A::Hermitian)
-    T = typeof(sqrt(zero(eltype(A))))
-    return eigvals!(_eigencopy_oftype(A, T))
-end
-function LinearAlgebra.eigen(A::Hermitian{<:Real})
-    T = typeof(sqrt(zero(eltype(A))))
-    return eigen!(_eigencopy_oftype(A, T))
-end
-function LinearAlgebra.eigen(A::Hermitian{<:Complex})
-    T = typeof(sqrt(zero(eltype(A))))
-    return eigen!(_eigencopy_oftype(A, T))
-end
-function LinearAlgebra.eigen(A::Hermitian)
-    T = typeof(sqrt(zero(eltype(A))))
-    return eigen!(_eigencopy_oftype(A, T))
+if VERSION < v"1.7"
+    function LinearAlgebra.eigvals(A::Hermitian{<:Real})
+        T = typeof(sqrt(zero(eltype(A))))
+        return eigvals!(_eigencopy_oftype(A, T))
+    end
+    function LinearAlgebra.eigvals(A::Hermitian{<:Complex})
+        T = typeof(sqrt(zero(eltype(A))))
+        return eigvals!(_eigencopy_oftype(A, T))
+    end
+    function LinearAlgebra.eigvals(A::Hermitian)
+        T = typeof(sqrt(zero(eltype(A))))
+        return eigvals!(_eigencopy_oftype(A, T))
+    end
+    function LinearAlgebra.eigen(A::Hermitian{<:Real})
+        T = typeof(sqrt(zero(eltype(A))))
+        return eigen!(_eigencopy_oftype(A, T))
+    end
+    function LinearAlgebra.eigen(A::Hermitian{<:Complex})
+        T = typeof(sqrt(zero(eltype(A))))
+        return eigen!(_eigencopy_oftype(A, T))
+    end
+    function LinearAlgebra.eigen(A::Hermitian)
+        T = typeof(sqrt(zero(eltype(A))))
+        return eigen!(_eigencopy_oftype(A, T))
+    end
 end
 
 # Aux (should go somewhere else at some point)

--- a/test/eigenselfadjoint.jl
+++ b/test/eigenselfadjoint.jl
@@ -164,4 +164,11 @@ using Test, GenericLinearAlgebra, LinearAlgebra, Quaternions
             @test eigen(A).values == diag(A)
         end
     end
+
+    if VERSION >= v"1.11"
+        @testset "Method ambiguity in eigen with Julia 1.11 #141" begin
+            M = Hermitian(Tridiagonal(ones(ComplexF64, 2), ones(ComplexF64, 3), ones(ComplexF64, 2)))
+            @test eigen(M).values ≈ Float64.(eigen(big.(M)).values)
+        end
+    end
 end


### PR DESCRIPTION
They don't seem to be needed anymore and avoid an ambiguity introduced by Julia 1.11. Also, sort the eigenvalues of the symmetric problem when nothing is passed.

Fixes #141 