### PR TITLE
Comment out @debug statements

### DIFF
--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -104,7 +104,7 @@ function _schur!(
 
     @inbounds while true
         i += 1
-        @debug "iteration" i
+        # @debug "iteration" i
         if i > maxiter
             throw(ArgumentError("iteration limit $maxiter reached"))
         end
@@ -118,7 +118,7 @@ function _schur!(
                 # Set istart to the beginning of the second block
                 istart = _istart + 1
 
-                @debug "Split!" HH[istart, istart-1] istart
+                # @debug "Split!" HH[istart, istart-1] istart
 
                 # Set the subdiagonal element to zero to signal that a split has taken place
                 HH[istart, istart-1] = 0
@@ -131,12 +131,12 @@ function _schur!(
 
         # if block size is one we deflate
         if istart >= iend
-            @debug "Bottom deflation! Block size is one. New iend is" iend - 1
+            # @debug "Bottom deflation! Block size is one. New iend is" iend - 1
             iend -= 1
 
             # and the same for a 2x2 block
         elseif istart + 1 == iend
-            @debug "Bottom deflation! Block size is two. New iend is" iend - 2
+            # @debug "Bottom deflation! Block size is two. New iend is" iend - 2
             iend -= 2
 
             # run a QR iteration
@@ -153,14 +153,14 @@ function _schur!(
                 d = Hm1m1 * Hmm - HH[iend, iend-1] * HH[iend-1, iend]
                 t = Hm1m1 + Hmm
             end
-            @debug "block start is, block end, d, and t" istart iend d t
+            # @debug "block start is, block end, d, and t" istart iend d t
 
             if shiftmethod == :Francis
-                @debug "Francis double shift!" HH[iend, iend-1] HH[iend-1, iend-2]
+                # @debug "Francis double shift!" HH[iend, iend-1] HH[iend-1, iend-2]
 
                 doubleShiftQR!(HH, τ, t, d, istart, iend)
             elseif shiftmethod == :Rayleigh
-                @debug "Single shift with Rayleigh shift!" HH[iend, iend-1]
+                # @debug "Single shift with Rayleigh shift!" HH[iend, iend-1]
 
                 # Run a bulge chase
                 singleShiftQR!(HH, τ, Hmm, istart, iend)

--- a/src/eigenSelfAdjoint.jl
+++ b/src/eigenSelfAdjoint.jl
@@ -183,20 +183,20 @@ function eigvalsPWK!(S::SymTridiagonal{T}; tol = eps(T), sortby::Union{Function,
                 blockend = n
             end
 
-            @debug "submatrix" blockstart blockend
+            # @debug "submatrix" blockstart blockend
 
             # Deflate?
             if blockstart == blockend
-                @debug "Deflate? Yes!"
+                # @debug "Deflate? Yes!"
                 blockstart += 1
             elseif blockstart + 1 == blockend
-                @debug "Defalte? Yes, but after solving 2x2 block!"
+                # @debug "Defalte? Yes, but after solving 2x2 block!"
                 d[blockstart], d[blockend] =
                     eigvals2x2(d[blockstart], d[blockend], sqrt(e[blockstart]))
                 e[blockstart] = zero(T)
                 blockstart += 1
             else
-                @debug "Deflate? No!"
+                # @debug "Deflate? No!"
                 # Calculate shift
                 sqrte = sqrt(e[blockstart])
                 μ = (d[blockstart+1] - d[blockstart]) / (2 * sqrte)
@@ -204,12 +204,12 @@ function eigvalsPWK!(S::SymTridiagonal{T}; tol = eps(T), sortby::Union{Function,
                 μ = d[blockstart] - sqrte / (μ + copysign(r, μ))
 
                 # QL bulk chase
-                @debug "Values before PWK QL bulge chase" e[blockstart] e[blockend-1] μ
+                # @debug "Values before PWK QL bulge chase" e[blockstart] e[blockend-1] μ
                 singleShiftQLPWK!(S, μ, blockstart, blockend)
 
                 rotations = blockend - blockstart
                 iter += rotations
-                @debug "Values after PWK QL bulge chase" e[blockstart] e[blockend-1] rotations
+                # @debug "Values after PWK QL bulge chase" e[blockstart] e[blockend-1] rotations
             end
             if blockstart >= n
                 break
@@ -259,27 +259,27 @@ function eigQL!(
                 blockend = n
             end
 
-            @debug "submatrix" blockstart blockend
+            # @debug "submatrix" blockstart blockend
 
             # Deflate?
             if blockstart == blockend
-                @debug "Deflate? Yes!"
+                # @debug "Deflate? Yes!"
                 blockstart += 1
             elseif blockstart + 1 == blockend
-                @debug "Deflate? Yes, but after solving 2x2 block"
+                # @debug "Deflate? Yes, but after solving 2x2 block"
                 eig2x2!(d, e, blockstart, vectors)
                 blockstart += 2
             else
-                @debug "Deflate? No!"
+                # @debug "Deflate? No!"
                 # Calculate shift
                 μ = (d[blockstart + 1] - d[blockstart]) / (2 * e[blockstart])
                 r = hypot(μ, one(T))
                 μ = d[blockstart] - (e[blockstart] / (μ + copysign(r, μ)))
 
                 # QL bulk chase
-                @debug "Values before bulge chase" e[blockstart] e[blockend - 1] d[blockstart] μ
+                # @debug "Values before bulge chase" e[blockstart] e[blockend - 1] d[blockstart] μ
                 singleShiftQL!(S, μ, blockstart, blockend, vectors)
-                @debug "Values after bulge chase" e[blockstart] e[blockend - 1] d[blockstart]
+                # @debug "Values after bulge chase" e[blockstart] e[blockend - 1] d[blockstart]
             end
 
             if blockstart >= n
@@ -312,27 +312,27 @@ function eigQR!(
                 blockend = n
             end
 
-            @debug "submatrix" blockstart blockend
+            # @debug "submatrix" blockstart blockend
 
             # Deflate?
             if blockstart == blockend
-                @debug "Deflate? Yes!"
+                # @debug "Deflate? Yes!"
                 blockstart += 1
             elseif blockstart + 1 == blockend
-                @debug "Deflate? Yes, but after solving 2x2 block!"
+                # @debug "Deflate? Yes, but after solving 2x2 block!"
                 eig2x2!(d, e, blockstart, vectors)
                 blockstart += 2
             else
-                @debug "Deflate? No!"
+                # @debug "Deflate? No!"
                 # Calculate shift
                 μ = (d[blockend - 1] - d[blockend]) / (2 * e[blockend - 1])
                 r = hypot(μ, one(T))
                 μ = d[blockend] - (e[blockend - 1] / (μ + copysign(r, μ)))
 
                 # QR bulk chase
-                @debug "Values before QR bulge chase" e[blockstart] e[blockend - 1] d[blockend] μ
+                # @debug "Values before QR bulge chase" e[blockstart] e[blockend - 1] d[blockend] μ
                 singleShiftQR!(S, μ, blockstart, blockend, vectors)
-                @debug "Values after QR bulge chase" e[blockstart] e[blockend - 1] d[blockend]
+                # @debug "Values after QR bulge chase" e[blockstart] e[blockend - 1] d[blockend]
             end
             if blockstart >= n
                 break

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -200,14 +200,14 @@ function __svd!(
                     break
                 end
             end
-            @debug "Active submatrix" iteration n1 n2 d[n1] d[n2] e[n1] e[n2 - 1]
+            # @debug "Active submatrix" iteration n1 n2 d[n1] d[n2] e[n1] e[n2 - 1]
 
             # Deflation check. See LAWN3 p21
             # The Demmel-Kahan iteration moves the zero to the end and produces a
             # zero super diagonal element as well
             for i = n1:n2
                 if d[i] == 0
-                    @debug "Deflation! Exact zero in diagonal element" i
+                    # @debug "Deflation! Exact zero in diagonal element" i
                     svdDemmelKahan!(B, n1, n2, U, Vᴴ)
 
                     # We have now moved a zero to the end so the problem is one smaller
@@ -230,7 +230,7 @@ function __svd!(
             fudge = n2 - n1 + 1
             thresh = tol * σ⁻
 
-            @debug "estimated quantities" σ⁻ σ⁺ fudge thresh
+            # @debug "estimated quantities" σ⁻ σ⁺ fudge thresh
 
             if fudge * tol * σ⁻ <= eps(σ⁺)
                 svdDemmelKahan!(B, n1, n2, U, Vᴴ)


### PR DESCRIPTION
Profiling reveals that there is a lot of overhead from them even at the default logging level. Hopefully that will improve over time. For now, users would have to uncomment these lines before debugging.

As an example

### Current master
```julia
julia> @btime GenericLinearAlgebra._eigen!(S) setup = (S = LinearAlgebra.SymTridiagonal(ones(100), 0.2*ones(99)));
  505.083 μs (12 allocations: 159.12 KiB)
```

### This PR
```julia
julia> @btime GenericLinearAlgebra._eigen!(S) setup = (S = LinearAlgebra.SymTridiagonal(ones(100), 0.2*ones(99)));
  153.222 μs (12 allocations: 159.12 KiB)
```