### PR TITLE
Rely on LinearAlgebra.eigsort! for sorting eigenvalues of the

### DIFF
--- a/test/eigenselfadjoint.jl
+++ b/test/eigenselfadjoint.jl
@@ -26,9 +26,8 @@ using Test, GenericLinearAlgebra, LinearAlgebra, Quaternions
         @testset "QR version (QL is default)" begin
             vals, vecs =
                 GenericLinearAlgebra.eigQR!(copy(T), vectors = Matrix{eltype(T)}(I, n, n))
-            @test issorted(vals)
             @test (vecs' * T) * vecs ≈ Diagonal(vals)
-            @test eigvals(T) ≈ vals
+            @test eigvals(T) ≈ sort(vals)
             @test vecs'vecs ≈ Matrix(I, n, n)
         end
     end


### PR DESCRIPTION
symmetric solver

Some profiling revealed that the sorting used until this PR had significant overhead for smaller and medium sized problems. In addition, the values would be sorted twice if the user supplied a non-standard sorting function.

As an example

### Current master
```julia
julia> @btime GenericLinearAlgebra._eigen!(S) setup = (S = LinearAlgebra.SymTridiagonal(ones(100), 0.2*ones(99)));
  153.222 μs (12 allocations: 159.12 KiB)
```

### This PR
```julia
julia> @btime GenericLinearAlgebra._eigen!(S) setup = (S = LinearAlgebra.SymTridiagonal(ones(100), 0.2*ones(99)));
  45.367 μs (3 allocations: 78.57 KiB)
```