### PR TITLE
svd!: allow lower bidiagonal

### DIFF
--- a/src/svd.jl
+++ b/src/svd.jl
@@ -153,13 +153,16 @@ end
 
 # The actual SVD solver routine
 # Notice that this routine doesn't adjust the sign and sorts the values
-function __svd!(
+function __svd!(B::Bidiagonal{T}, args...; kwargs...) where {T<:Real}
+    B.uplo == 'U' ? __svd_helper!(B, args...; kwargs...) : __svd_helper!(B', args...; kwargs...)
+end
+
+function __svd_helper!(
     B::Bidiagonal{T},
     U = nothing,
     Vᴴ = nothing;
     tol = 100eps(T),
 ) where {T<:Real}
-
     n = size(B, 1)
     if n == 0
         # Exit early in the empty case


### PR DESCRIPTION
Close JuliaLinearAlgebra/TSVD.jl#33

TSVD requires the SVD of a lower bidiagonal matrix. If the element type is not one supported by LAPACK and if GenericLinearAlgebra is imported, the call dispatches to it. However, GenericLinearAlgebra only implements the SVD of an *upper* bidiagonal.
This PR introduces a helper function to pass the transposed of the bidiagonal if the latter is a lower bidiagonal.
As a result, the truncated SVD of a matrix of, say, BigFloat, is now possible.