### PR TITLE
Convert lower to upper bidgiagonal in _svd! and _svdvals!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GenericLinearAlgebra"
 uuid = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
-version = "0.3.17"
+version = "0.3.18"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -266,4 +266,12 @@ using Test, GenericLinearAlgebra, LinearAlgebra, Quaternions, DoubleFloats
         @test svdvals(BigFloat[0 0; 1 -1]) ≈ [sqrt(2), 0]
         @test svdvals(BigFloat[1 0 0; 0 0 0; 0 1 -1]) ≈ [sqrt(2), 1, 0]
     end
+
+    @testset "Lower Bidiagonal matrices. Issue 157" begin
+        B = Bidiagonal(randn(4), randn(3), :L)
+        @test GenericLinearAlgebra._svdvals!(copy(B)) ≈ GenericLinearAlgebra._svdvals!(copy(B'))
+        U, s, V = GenericLinearAlgebra._svd!(copy(B))
+        @test B ≈ U * Diagonal(s) * V'
+        @test_throws ArgumentError("please convert to upper bidiagonal") GenericLinearAlgebra.svdIter!(B, 1, size(B, 1), 1.0)
+    end
 end


### PR DESCRIPTION
This is done by running a single pass of givens rotations from the left while also updating the U matrix. For svdvals!, the uplo field is simply flipped as the singular values of the transpose are the same.

Supersedes #156. Closes #157.