### PR TITLE
use correct upper bound for eigencopy_oftype

### DIFF
--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -10,7 +10,7 @@ if VERSION < v"1.10"
     LinearAlgebra.eigvals(A::UpperHessenberg{T}; kws...) where T = LinearAlgebra.eigvals!(eigencopy_oftype(A, eigtype(T)); kws...)
     Base.:\(H::UpperHessenberg, B::AbstractVecOrMat) = ldiv!(copy(H), copy(B))
 end
-if v"1.10" ≤ VERSION < v"1.14"
+if v"1.10" ≤ VERSION < v"1.14.0-DEV.2266"
     #otherwise the Hessenberg shortcut is not used
     LinearAlgebra.eigencopy_oftype(H::UpperHessenberg, S) = UpperHessenberg(LinearAlgebra.eigencopy_oftype(H.data, S))
 end


### PR DESCRIPTION
Otherwise precompilation will fail on all pre-release versions of Julia 1.14, which also ruins the precompilation of dependencies such as `DoubleFloats`.