### PR TITLE
fix precompilation on 1.13

### DIFF
--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -10,7 +10,7 @@ if VERSION < v"1.10"
     LinearAlgebra.eigvals(A::UpperHessenberg{T}; kws...) where T = LinearAlgebra.eigvals!(eigencopy_oftype(A, eigtype(T)); kws...)
     Base.:\(H::UpperHessenberg, B::AbstractVecOrMat) = ldiv!(copy(H), copy(B))
 end
-if v"1.10" ≤ VERSION < v"1.14.0-DEV.2266"
+if v"1.10" ≤ VERSION < v"1.13.0-rc2"
     #otherwise the Hessenberg shortcut is not used
     LinearAlgebra.eigencopy_oftype(H::UpperHessenberg, S) = UpperHessenberg(LinearAlgebra.eigencopy_oftype(H.data, S))
 end


### PR DESCRIPTION
Part of #180 

The Hessenberg changes were backported to 1.13, so the compat bound needs to be changed here as well. Unfortunately the bugfix https://github.com/JuliaLang/LinearAlgebra.jl/pull/1602 wasn't backported together with it, so `GenericLinearAlgebra` will remain broken until that happens.